### PR TITLE
Deprecated usage of '@' at the beginning

### DIFF
--- a/controllers/products/config_relation.yaml
+++ b/controllers/products/config_relation.yaml
@@ -4,8 +4,8 @@
 
 customfields:
     label: false # Could not translate in lang.php because it's not parsed in custom field creation form
-    list: @/plugins/tiipiik/catalog/models/customvalue/columns.yaml
-    form: @/plugins/tiipiik/catalog/models/customvalue/fields.yaml
+    list: $/tiipiik/catalog/models/customvalue/columns.yaml
+    form: $/tiipiik/catalog/models/customvalue/fields.yaml
     emptyMessage: Product has no custom field
     toolbar: 
         buttons: false


### PR DESCRIPTION
The last build (322) of October CMS returns an exception

![Error](https://box.everhelper.me/attachment/437216/542048c5-6321-40cb-8afd-c68b12d268f9/397815-YDixAWvbWyOlPAFt/screen.png)
