### PR TITLE
Fixes for product list pagination and images not being deleted from system files when a record is deleted

### DIFF
--- a/components/ProductList.php
+++ b/components/ProductList.php
@@ -170,7 +170,7 @@ class ProductList extends ComponentBase
         }
         
         $products = Product::with('customfields')->with('categories')->listFrontEnd([
-            'page' => $this->property('pageParam'),
+            'page' => $this->property('pageNumber'),
             'sort'       => $this->property('sortOrder'),
             'perPage' => $this->property('productsPerPage'),
             'categories' => $categories,

--- a/models/Brand.php
+++ b/models/Brand.php
@@ -56,7 +56,7 @@ class Brand extends Model
      * @var array Relations
      */
     public $attachOne = [
-        'cover_image' => ['System\Models\File', 'order' => 'sort_order','delete' => true],
+        'cover_image' => ['System\Models\File', 'order' => 'sort_order', 'delete' => true],
     ];
     
     public $hasMany = [

--- a/models/Brand.php
+++ b/models/Brand.php
@@ -56,7 +56,7 @@ class Brand extends Model
      * @var array Relations
      */
     public $attachOne = [
-        'cover_image' => ['System\Models\File', 'order' => 'sort_order'],
+        'cover_image' => ['System\Models\File', 'order' => 'sort_order','delete' => true],
     ];
     
     public $hasMany = [

--- a/models/Category.php
+++ b/models/Category.php
@@ -44,7 +44,7 @@ class Category extends Model
     ];
 
     public $attachOne = [
-        'cover' => ['System\Models\File','delete' => true]
+        'cover' => ['System\Models\File', 'delete' => true]
     ];
     
      /**

--- a/models/Category.php
+++ b/models/Category.php
@@ -44,7 +44,7 @@ class Category extends Model
     ];
 
     public $attachOne = [
-        'cover' => ['System\Models\File']
+        'cover' => ['System\Models\File','delete' => true]
     ];
     
      /**

--- a/models/Product.php
+++ b/models/Product.php
@@ -80,7 +80,7 @@ class Product extends Model
      * @var array Relations
      */
     public $attachMany = [
-        'featured_images' => ['System\Models\File'],
+        'featured_images' => ['System\Models\File', 'delete' => true],
     ];
     
     public $belongsTo = [

--- a/models/Store.php
+++ b/models/Store.php
@@ -65,7 +65,7 @@ class Store extends Model
     ];
     
     public $attachOne = [
-        'cover_image' => ['System\Models\File'],
+        'cover_image' => ['System\Models\File','delete' => true],
     ];
     
      /**

--- a/models/Store.php
+++ b/models/Store.php
@@ -65,7 +65,7 @@ class Store extends Model
     ];
     
     public $attachOne = [
-        'cover_image' => ['System\Models\File','delete' => true],
+        'cover_image' => ['System\Models\File', 'delete' => true],
     ];
     
      /**


### PR DESCRIPTION
When a product, category or brand is removed the images attached stay in the system_files table.  So for example when a product gets deleted the file remains.  When the plugin is refreshed the old images get attached to the new product.  

Added delete => true to removes the file on deletion of the records.

Also a fix for the product list pagination not working
